### PR TITLE
Don't use gda 1.1.2

### DIFF
--- a/rubocop-isucon.gemspec
+++ b/rubocop-isucon.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |spec|
   # guide at: https://bundler.io/guides/creating_gem.html
 
   spec.add_runtime_dependency "activerecord", ">= 6.1.0"
-  spec.add_runtime_dependency "gda"
+  spec.add_runtime_dependency "gda", "!= 1.1.2"
   spec.add_runtime_dependency "rubocop", ">= 1.25.0"
   spec.add_runtime_dependency "rubocop-performance"
 


### PR DESCRIPTION
I think 1.1.2 is broken

```
$ bubdle exec rspec

An error occurred while loading spec_helper. - Did you mean?
                    rspec ./spec/spec_helper.rb

Failure/Error: require "gda"

LoadError:
  cannot load such file -- gda/gda
# ./vendor/bundle/ruby/3.1.0/gems/gda-1.1.2/lib/gda.rb:1:in `require'
# ./vendor/bundle/ruby/3.1.0/gems/gda-1.1.2/lib/gda.rb:1:in `<top (required)>'
# ./lib/rubocop-isucon.rb:5:in `require'
# ./lib/rubocop-isucon.rb:5:in `<top (required)>'
# ./spec/spec_helper.rb:3:in `require'
# ./spec/spec_helper.rb:3:in `<top (required)>'
No examples found.

Finished in 0.00005 seconds (files took 1.14 seconds to load)
0 examples, 0 failures, 1 error occurred outside of examples
```

c.f. 

* https://github.com/sue445/rubocop-isucon/runs/5522124072?check_suite_focus=true
* https://github.com/tenderlove/gda/compare/v1.1.1...v1.1.2